### PR TITLE
Updated package references and binary file name to match newer Node.js requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./src/Index.js",
   "scripts": {
     "test-one": "./node_modules/mocha/bin/mocha --require esm './test/Util.test.js'",
-    "test": "./node_modules/mocha/bin/mocha --require esm --recursive './test/**/*.test.js'"
+    "test": "./node_modules/mocha/bin/mocha.js --require esm --recursive './test/**/*.test.js'"
   },
   "keywords": [],
   "author": {

--- a/src/Index.js
+++ b/src/Index.js
@@ -1,4 +1,4 @@
-import Util from './Util';
+import Util from './Util.js';
 
 function process(param) {
     return Util(param);

--- a/test/Index.test.js
+++ b/test/Index.test.js
@@ -1,4 +1,4 @@
-import Index from '../src/Index';
+import Index from '../src/Index.js';
 import {describe, it} from 'mocha';
 import assert from 'assert';
 

--- a/test/Util.test.js
+++ b/test/Util.test.js
@@ -1,4 +1,4 @@
-import Util from '../src/Util';
+import Util from '../src/Util.js';
 import {describe, it} from 'mocha';
 import assert from 'assert';
 


### PR DESCRIPTION
Thank you for creating the demo repo. I was beginning to think it was impossible to use Mocha with any form of ESM modules, but this definitely proves otherwise. 

I had some trouble running the demo because I believe Node.js changed the requirements so that file extensions are required when importing files.  I added the extensions.

Also, the mocha Node binary appears to be `mocha.js` instead of `mocha`.  Making this change allowed the tests to run and pass successfully.

Hope this helps, and thank you again for sharing this!